### PR TITLE
fix(android): Fix launching camera when targeting SDK 30

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -302,15 +302,11 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
         if (this.cordova != null) {
-            // Let's check to make sure the camera is actually installed. (Legacy Nexus 7 code)
-            PackageManager mPm = this.cordova.getActivity().getPackageManager();
-            if(intent.resolveActivity(mPm) != null)
-            {
+            try {
                 this.cordova.startActivityForResult((CordovaPlugin) this, intent, (CAMERA + 1) * 16 + returnType + 1);
-            }
-            else
-            {
-                LOG.d(LOG_TAG, "Error: You don't have a default camera.  Your device may not be CTS complaint.");
+            } catch(ActivityNotFoundException e) {
+                e.printStackTrace();
+                LOG.e(LOG_TAG, "Error: You don't have a default camera.  Your device may not be CTS complaint.");
             }
         }
 //        else


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #673

The Android 11 (API Level 30) migration has some changes regarding package visibility. [This page](https://developer.android.com/training/package-visibility/use-cases) mentions:

> When your app targets Android 11 or higher and uses an intent to start an activity in another app, the most straightforward approach is to invoke the intent and handle the ActivityNotFoundException exception if no app is available.

Currently, this  plugin tries to resole the intent by querying the Package Manager, seemingly for a workaround for Nexus 7. 


### Description
<!-- Describe your changes in detail -->
This PR attempts to start the activity and handle the ActivityNotFoundException error (if thrown). 


### Testing
<!-- Please describe in detail how you tested your changes. -->
I ran `npm test`
I tested this on an Android 11 device with an app targeting SDK 30 and it launched the camera fine. 
I haven't tested this on Nexus 7, but I did also test on a device with no camera app installed (disabled via ADB) and the error was handled gracefully.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
